### PR TITLE
4-add-configurability: Remove hardwired dependency on bosh-lite.com, …

### DIFF
--- a/api/profiles/hcf.properties
+++ b/api/profiles/hcf.properties
@@ -1,0 +1,10 @@
+cfUrl=api.<%= p('system_domain') %>
+cfClientId=cf-autoscaler-client
+cfClientSecret=<%= p('uaa.clients.cf-autoscaler-client.secret') %>
+
+# "internalAuth" is actually the autoscaler server's auth
+internalAuthUsername=<%= p('autoscaler_server.internal_auth.username') %>
+internalAuthPassword=<%= p('autoscaler_server.internal_auth.password') %>
+
+#interval of data colletion
+reportInterval=120

--- a/bosh-release/jobs/autoscaler_api/spec
+++ b/bosh-release/jobs/autoscaler_api/spec
@@ -12,3 +12,9 @@ properties:
   tomcat.http.port:
     description: the http port for tomocat server
     default: 80
+  autoscaler_api:
+    internal_auth:
+      username:
+        description: the autoscaler-API's username
+      password:
+        description: the autoscaler-API's password

--- a/server/profiles/hcf.properties
+++ b/server/profiles/hcf.properties
@@ -1,14 +1,15 @@
 #valid for couchdb
-couchdbUsername=
-couchdbPassword=
-couchdbHost=
-couchdbPort=5984
+couchdbUsername=<%= p('couchdb.username') %>
+couchdbPassword=<%= p('couchdb.password') %>
+couchdbHost=<%= p('couchdb.host') %>
+couchdbPort=<%= p('couchdb.port') %>
 couchdbDBName=couchdb-scaling
 couchdbMetricDBPrefix=couchdb-scalingmetric
 
-cfUrl=api.bosh-lite.com
+#xcfUrl=autoscaler-api.192.168.77.77.nip.io
+cfUrl=api.<%= p('system_domain') %>
 cfClientId=cf-autoscaler-client
-cfClientSecret=cf-autoscaler-client-secret
+cfClientSecret=<%= p('uaa.clients.cf-autoscaler-client.secret') %>
 
 #interval of data colletion
 reportInterval=120

--- a/servicebroker/profiles/hcf.properties
+++ b/servicebroker/profiles/hcf.properties
@@ -1,0 +1,23 @@
+service.name=CF-AutoScaler
+
+#xserverURIList=AutoScaling.bosh-lite.com
+#xapiServerURI=AutoScalingAPI.bosh-lite.com
+serverURIList=autoscaler-server.<%= p('system_domain') %>:28862/server
+apiServerURI=autoscaler-api.<%= p('system_domain') %>:28861/api
+httpProtocol=https
+
+#Token for /v2/* apis
+brokerUsername=admin
+brokerPassword=admin
+
+#valid for couchdb
+couchdbUsername=<%= p('couchdb.username') %>
+couchdbPassword=<%= p('couchdb.password') %>
+couchdbHost=<%= p('couchdb.host') %>
+couchdbPort=<%= p('couchdb.port') %>
+couchdbDBName=<%= p('couchdb.dbname') %> # couchdb-scalingbroker
+
+# "internalAuth" is the autoscaler server's auth
+internalAuthUsername=<%= p('autoscaler_server.internal_auth.username') %>
+internalAuthPassword=<%= p('autoscaler_server.internal_auth.password') %>
+


### PR DESCRIPTION
…and more

This assumes existence of the following global properties:
- system_domain
- uaa.clients.cf-autoscaler-client.secret
- couchdb.username
- couchdb.password
- couchdb.host
- couchdb.port
- couchdb.dbname
